### PR TITLE
Fix AuthMode cannot be null, replace by login

### DIFF
--- a/Smtp/GmailTransport.php
+++ b/Smtp/GmailTransport.php
@@ -24,7 +24,7 @@ class GmailTransport extends EsmtpTransport
 {
     public function __construct(string $username, string $password, EventDispatcherInterface $dispatcher = null, LoggerInterface $logger = null)
     {
-        parent::__construct('smtp.gmail.com', 465, 'ssl', null, $dispatcher, $logger);
+        parent::__construct('smtp.gmail.com', 465, 'ssl', 'login', $dispatcher, $logger);
 
         $this->setUsername($username);
         $this->setPassword($password);


### PR DESCRIPTION
I created an article for Mailer component, when i add all information with GmailTransport (username and password (or password app)).
I have got this error : 
![image](https://user-images.githubusercontent.com/10236869/63597827-996c9900-c5be-11e9-9198-77eefb80ab42.png)

I see in GmailTransport, Authmode is null then cannot be null for Gmail.